### PR TITLE
HOTFIX/20210529

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,8 @@
 
 ## `1.0.0`
 
-* First release;
+* First release.
+
+## `1.0.1` at `2021-05-29`
+
+* Fix `json_decode()` as associative array at `Request::call()` method.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Api Client Starter-Kit
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/piggly/php-php-api-client.svg?style=flat-square)](https://packagist.org/packages/piggly/php-api-client) [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE) 
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/piggly/php-api-client.svg?style=flat-square)](https://packagist.org/packages/piggly/php-api-client) [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE) 
 
 This open-source library is provided for cases where you need to do APIs calls with large flexibility that officials SDK may not provide out-of-the-box. When using this Starter-Kit, you will be able to make better cURL requests with a smart managing of requests and responses.
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -594,7 +594,7 @@ class Request
 		// Invalid response
 		if ( $response_info['http_code'] < 200 || $response_info['http_code'] >= 300 )
 		{
-			$data = \json_decode( $http_body );
+			$data = \json_decode( $http_body, true );
 
 			// Cannot decode json, restore raw body
 			if ( \json_last_error() > 0 )


### PR DESCRIPTION
Fix `json_decode()` as associative array at `Request::call()` method.